### PR TITLE
Fix leaking references to internal state

### DIFF
--- a/src/simpla.js
+++ b/src/simpla.js
@@ -125,6 +125,9 @@ const Simpla = new class Simpla {
         pathInStore,
         wrappedCallback;
 
+    // Clone so as to not affect given param
+    query = Object.assign({}, query);
+
     query.parent = pathToUid(query.parent);
     queryString = toQueryParams(query);
     pathInStore = [ QUERIES_PREFIX, queryString, 'matches' ];

--- a/src/simpla.js
+++ b/src/simpla.js
@@ -19,7 +19,8 @@ import {
   queryResultsToPath,
   validatePath,
   toQueryParams,
-  uidsToResponse
+  uidsToResponse,
+  clone
 } from './utils/helpers';
 import ping from './plugins/ping';
 import persistToken from './plugins/persistToken';
@@ -63,7 +64,8 @@ const Simpla = new class Simpla {
         find(options),
         types.FIND_DATA_SUCCESSFUL
       ))
-      .then(queryResultsToPath);
+      .then(queryResultsToPath)
+      .then(clone);
   }
 
   get(path, ...args) {
@@ -75,7 +77,8 @@ const Simpla = new class Simpla {
         get(uid, ...args),
         types.GET_DATA_SUCCESSFUL
       ))
-      .then(itemUidToPath);
+      .then(itemUidToPath)
+      .then(clone);
   }
 
   set(path, ...args) {
@@ -137,7 +140,7 @@ const Simpla = new class Simpla {
     wrappedCallback = (uids) => {
       return callback(
         queryResultsToPath(
-          uidsToResponse(uids, this._store.getState())
+          clone(uidsToResponse(uids, this._store.getState()))
         )
       );
     }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -140,12 +140,30 @@ export function dispatchThunkAndExpect(store, ...args) {
 }
 
 /**
- * Clone's the given object using JSON.parse(JSON.stringify(...));
+ * Deep clone's the given object recursively. Doesn't touch object's prototype,
+ *  and only clones obejct, arrays and primitives.
  * @param  {Object} object Object should be JSON compatible
  * @return {Object}        Clone of given object
  */
-export function clone(object) {
-  return JSON.parse(JSON.stringify(object));
+export function clone(subject) {
+  var cloned;
+
+  if (typeof subject !== 'object' || !subject) {
+    return subject;
+  }
+
+  if ('[object Array]' === Object.prototype.toString.apply(subject)) {
+    return subject.map(clone);
+  }
+
+  cloned = {};
+  for (let key in subject) {
+    if (subject.hasOwnProperty(key)) {
+      cloned[key] = clone(subject[key]);
+    }
+  }
+
+  return cloned;
 }
 
 export function dataIsValid(data) {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -5,6 +5,7 @@
 
   "globals": {
     "expect": true,
-    "sinon": true
+    "sinon": true,
+    "_": true
   }
 }

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -11,7 +11,8 @@ import {
   uidToPath,
   itemUidToPath,
   validatePath,
-  matchesQuery
+  matchesQuery,
+  clone
 } from '../../src/utils/helpers';
 import {
   DATA_PREFIX
@@ -418,6 +419,34 @@ describe('helpers', () => {
         .forEach(path => {
           expect(validatePath.bind(null, path), path).not.to.throw();
         });
+    });
+  });
+
+  describe('clone', () => {
+    it('should behave the same as JSON.stringify -> parse', () => {
+      [
+        false,
+        true,
+        [],
+        {},
+        null,
+        1,
+        {
+          foo: [
+            'bar',
+            {
+              bar: [1, '', { bar: 'baz' }]
+            }
+          ]
+        },
+        [{ foo: 'bar' }, null ]
+      ].forEach(testCase => {
+        expect(clone(testCase)).to.deep.equal(JSON.parse(JSON.stringify(testCase)));
+      });
+    });
+
+    it('should also be able to handle undefined', () => {
+      expect(clone(undefined)).to.equal(undefined);
     });
   });
 });


### PR DESCRIPTION
Currently get / find / observer methods are sometimes returning references to the internal state, which means changes to these objects will affect Simpla's internal state e.g.

```js
Simpla.get('/image')
  .then(item => {
    item.data.alt = 'Some image'
  })
  .then(() => Simpla.get('/image'))
  .then(item => {
    // item.data.alt === 'Some Image'
  });
```

This PR patches this by ensuring all data returned is a deep clone of the state's data.
