### PR TITLE
Minor queries cleanup

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -16,41 +16,42 @@ import {
   REMOVE_DATA_FROM_API_FAILED
 } from '../constants/actionTypes';
 import client from '../utils/client';
-import { toQueryParams } from '../utils/helpers';
+import { toQueryParams, toUidQuery, pathToUid, pathIsInvalid, itemUidToPath } from '../utils/helpers';
 
-/**
- * Check if uid is invalid. If invalid, returns message why, otherwise returns
- * 	false
- * @param  {String} uid
- * @return {Boolean}
- */
-function isInvalid(uid) {
-  if (typeof uid !== 'undefined' && uid === '') {
-    return 'Invalid UID: Empty string is not a valid UID';
-  }
-}
-
-function formatAndRun({ uid = '', validateUid = true, query, endpoint: dataEndpoint, token, method, body }) {
-  const endpoint = `${dataEndpoint}/${encodeURIComponent(uid)}${toQueryParams(query)}`,
-        invalid = isInvalid(uid);
-
-  if (validateUid && invalid) {
-    return Promise.reject(new Error(invalid));
+function formatAndRun({ path = '', shouldValidate = true, query, endpoint, token, method, body }) {
+  const uid = pathToUid(path),
+        uri = `${endpoint}/${encodeURIComponent(uid)}${toQueryParams(toUidQuery(query))}`;
+  
+  if (shouldValidate) {
+    let invalid = pathIsInvalid(path);
+    if (invalid) {
+      return Promise.reject(invalid);
+    }
   }
 
-  return client[method](endpoint, {
+  return client[method](uri, {
     body,
     token
+  }).then(response => {
+    if (response) {
+      if (response.items) {
+        response.items = response.items.map(itemUidToPath);
+      } else {
+        response = itemUidToPath(response);
+      }
+    }
+
+    return response;
   });
 }
 
-function generateHandler(method, paramsToObj, [ start, success, fail ], validateUid) {
+function generateHandler(method, paramsToObj, [ start, success, fail ], shouldValidate) {
   return (...args) => (dispatch, getState) => {
     let { config, token } = getState(),
         endpoint = config.dataEndpoint,
         options;
 
-    options = Object.assign({ method, endpoint, token, validateUid }, paramsToObj(...args));
+    options = Object.assign({ method, endpoint, token, shouldValidate }, paramsToObj(...args));
 
     dispatch(start(...args));
     return formatAndRun(options)
@@ -65,19 +66,19 @@ export const findData = (query) => ({ type: FIND_DATA_FROM_API, query });
 export const findDataSuccessful = (query, response) => ({ type: FIND_DATA_FROM_API_SUCCESSFUL, query, response });
 export const findDataFailed = (query, response) => ({ type: FIND_DATA_FROM_API_FAILED, query, response });
 
-export const getData = (uid) => ({ type: GET_DATA_FROM_API, uid });
-export const getDataSuccessful = (uid, response) => ({ type: GET_DATA_FROM_API_SUCCESSFUL, uid, response });
-export const getDataFailed = (uid, response) => ({ type:  GET_DATA_FROM_API_FAILED, uid, response });
+export const getData = (path) => ({ type: GET_DATA_FROM_API, path });
+export const getDataSuccessful = (path, response) => ({ type: GET_DATA_FROM_API_SUCCESSFUL, path, response });
+export const getDataFailed = (path, response) => ({ type:  GET_DATA_FROM_API_FAILED, path, response });
 
-export const setData = (uid, body) => ({ type: SET_DATA_TO_API, uid, body });
-export const setDataSuccessful = (uid, body, response) => ({ type: SET_DATA_TO_API_SUCCESSFUL, uid, body, response });
-export const setDataFailed = (uid, body, response) => ({ type:  SET_DATA_TO_API_FAILED, uid, body, response });
+export const setData = (path, body) => ({ type: SET_DATA_TO_API, path, body });
+export const setDataSuccessful = (path, body, response) => ({ type: SET_DATA_TO_API_SUCCESSFUL, path, body, response });
+export const setDataFailed = (path, body, response) => ({ type:  SET_DATA_TO_API_FAILED, path, body, response });
 
-export const removeData = (uid) => ({ type: REMOVE_DATA_FROM_API, uid });
-export const removeDataSuccessful = (uid, response) => ({ type: REMOVE_DATA_FROM_API_SUCCESSFUL, uid, response });
-export const removeDataFailed = (uid, response) => ({ type:  REMOVE_DATA_FROM_API_FAILED, uid, response });
+export const removeData = (path) => ({ type: REMOVE_DATA_FROM_API, path });
+export const removeDataSuccessful = (path, response) => ({ type: REMOVE_DATA_FROM_API_SUCCESSFUL, path, response });
+export const removeDataFailed = (path, response) => ({ type:  REMOVE_DATA_FROM_API_FAILED, path, response });
 
-export const get = generateHandler('get', (uid) => ({ uid }), [ getData, getDataSuccessful, getDataFailed ]);
-export const set = generateHandler('put', (uid, body) => ({ uid, body }), [ setData, setDataSuccessful, setDataFailed ]);
-export const remove = generateHandler('delete', (uid) => ({ uid }), [ removeData, removeDataSuccessful, removeDataFailed ]);
+export const get = generateHandler('get', (path) => ({ path }), [ getData, getDataSuccessful, getDataFailed ]);
+export const set = generateHandler('put', (path, body) => ({ path, body }), [ setData, setDataSuccessful, setDataFailed ]);
+export const remove = generateHandler('delete', (path) => ({ path }), [ removeData, removeDataSuccessful, removeDataFailed ]);
 export const find = generateHandler('get', (query) => ({ query }), [ findData, findDataSuccessful, findDataFailed ], false);

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -29,6 +29,10 @@ function formatAndRun({ path = '', shouldValidate = true, query, endpoint, token
     }
   }
 
+  if (body) {
+    delete body.path;
+  }
+
   return client[method](uri, {
     body,
     token

--- a/src/actions/save.js
+++ b/src/actions/save.js
@@ -39,7 +39,7 @@ export default function save() {
     dispatch(startSave());
 
     const buffer = getState().buffer.verbose,
-          entries = Object.keys(buffer).map(uid => [ uid, buffer[uid] ]);
+          entries = Object.keys(buffer).map(path => [ path, buffer[path] ]);
 
     shouldRemove = ([, { local, changed }]) => local === null && changed;
     shouldSet = ([, { local, changed }]) => local !== null && changed;
@@ -47,14 +47,14 @@ export default function save() {
     saveResultLocally = (result) => {
       return runDispatchAndExpect(
         dispatch,
-        setLocally(result.id, result, { validate: false }),
+        setLocally(result.path, result, { validate: false }),
         SET_DATA_SUCCESSFUL
       );
     };
 
     setPromises = entries
       .filter(shouldSet)
-      .map(([ uid, { local } ]) => set(uid, local))
+      .map(([ path, { local } ]) => set(path, local))
       .map(action => {
         return runDispatchAndExpect(dispatch, action, SET_DATA_TO_API_SUCCESSFUL)
           .then(saveResultLocally);
@@ -62,7 +62,7 @@ export default function save() {
 
     removePromises = entries
       .filter(shouldRemove)
-      .map(([ uid ]) => remove(uid))
+      .map(([ path ]) => remove(path))
       .map(action => runDispatchAndExpect(dispatch, action, REMOVE_DATA_FROM_API_SUCCESSFUL));
 
     return Promise.all([ ...setPromises, ...removePromises ])

--- a/src/reducers/data.js
+++ b/src/reducers/data.js
@@ -1,42 +1,7 @@
 import { SET_DATA_SUCCESSFUL, REMOVE_DATA_SUCCESSFUL } from '../constants/actionTypes';
 import { clone, jsonIsEqual } from '../utils/helpers';
-import { combineReducers } from 'redux';
 
-function markAt(state, path) {
-  let key = path[0],
-      value = path.length === 1 ? {} : markAt(state[key] || {}, path.slice(1));
-
-  return Object.assign({}, state, { [key]: value });
-}
-
-function pruneAt(state, path) {
-  let key = path[0];
-
-  if (path.length === 1) {
-    let newState = Object.assign({}, state);
-    delete newState[key];
-    return newState;
-  }
-
-  if (state.hasOwnProperty(key)) {
-    return Object.assign({}, state, { [key]: pruneAt(state[key], path.slice(1)) });
-  }
-
-  return state;
-}
-
-export function hierarchy(state = {}, action) {
-  switch (action.type) {
-  case SET_DATA_SUCCESSFUL:
-    return markAt(state, action.uid.split('.'), {});
-  case REMOVE_DATA_SUCCESSFUL:
-    return pruneAt(state, action.uid.split('.'));
-  default:
-    return state;
-  }
-}
-
-export function content(state = {}, action) {
+export default function content(state = {}, action) {
   switch (action.type) {
   case SET_DATA_SUCCESSFUL:
     let currentContent = state[action.uid],
@@ -57,5 +22,3 @@ export function content(state = {}, action) {
     return state;
   }
 }
-
-export default combineReducers({ hierarchy, content });

--- a/src/reducers/data.js
+++ b/src/reducers/data.js
@@ -4,20 +4,20 @@ import { clone, jsonIsEqual } from '../utils/helpers';
 export default function content(state = {}, action) {
   switch (action.type) {
   case SET_DATA_SUCCESSFUL:
-    let currentContent = state[action.uid],
+    let currentContent = state[action.path],
         newContent = clone(action.response);
 
     if (jsonIsEqual(currentContent, newContent)) {
       return state;
     }
 
-    return Object.assign({}, state, { [ action.uid ]: clone(action.response) });
+    return Object.assign({}, state, { [ action.path ]: clone(action.response) });
   case REMOVE_DATA_SUCCESSFUL:
-    if (state[action.uid] === null) {
+    if (state[action.path] === null) {
       return state;
     }
 
-    return Object.assign({}, state, { [ action.uid ]: null });
+    return Object.assign({}, state, { [ action.path ]: null });
   default:
     return state;
   }

--- a/src/reducers/queries.js
+++ b/src/reducers/queries.js
@@ -91,14 +91,14 @@ export default function queries(state = {}, action) {
     return Object.keys(state)
       .reduce((state, queryString) => {
         let { query, matches, cache, querying } = state[queryString],
-            { response, uid } = action,
+            { response, path } = action,
             current = querying ? cache : matches,
             updated;
 
         if (!matchesQuery(query, response)) {
-          updated = current.filter(isNot(uid));
-        } else if (current.indexOf(uid) === -1) {
-          updated = [ ...current, uid ];
+          updated = current.filter(isNot(path));
+        } else if (current.indexOf(path) === -1) {
+          updated = [ ...current, path ];
         } else {
           return state;
         }
@@ -115,10 +115,10 @@ export default function queries(state = {}, action) {
     return Object.keys(state)
       .reduce((state, queryString) => {
         let { matches } = state[queryString],
-            { uid } = action,
+            { path } = action,
             updatedMatches;
 
-        updatedMatches = matches.filter(isNot(uid));
+        updatedMatches = matches.filter(isNot(path));
 
         if (updatedMatches !== matches.length) {
           return updateStateWithQuery(state, queryString, {

--- a/src/simpla.js
+++ b/src/simpla.js
@@ -1,5 +1,5 @@
 import 'es6-promise/auto';
-import { createStore, applyMiddleware, compose } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import { setOption } from './actions/options';
 import { editActive, editInactive } from './actions/editable';
 import { login, logout } from './actions/authentication';
@@ -32,8 +32,7 @@ configurePolymer();
 
 const Simpla = new class Simpla {
   constructor() {
-    const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-    this._store = createStore(rootReducer, composeEnhancers(applyMiddleware(thunk)));
+    this._store = createStore(rootReducer, applyMiddleware(thunk));
   }
 
   init(project) {

--- a/src/simpla.js
+++ b/src/simpla.js
@@ -134,7 +134,7 @@ const Simpla = new class Simpla {
 
     validatePath(path);
 
-    pathInState = [ DATA_PREFIX, 'content', uid ];
+    pathInState = [ DATA_PREFIX, uid ];
     wrappedCallback = () => this.get(path).then(callback);
 
     return storeToObserver(this._store).observe(pathInState, wrappedCallback);
@@ -159,7 +159,7 @@ const Simpla = new class Simpla {
 
     queryString = toQueryParams(query);
     pathInStore = [ QUERIES_PREFIX, queryString, 'matches' ];
-    content = this._store.getState()[DATA_PREFIX].content;
+    content = this._store.getState()[DATA_PREFIX];
 
     this._store.dispatch(observeQuery({ query, content }));
 

--- a/src/simpla.js
+++ b/src/simpla.js
@@ -14,7 +14,7 @@ import {
   storeToObserver,
   dispatchThunkAndExpect,
   pathToUid,
-  selectPropByPath,
+  get as getByPath,
   itemUidToPath,
   queryResultsToPath,
   validatePath,
@@ -191,15 +191,13 @@ const Simpla = new class Simpla {
     let state = this._store.getState();
 
     if (substate) {
-      let path = PUBLIC_STATE_MAP[substate];
-      return path ? selectPropByPath(path, state) : undefined;
+      return PUBLIC_STATE_MAP[substate] && getByPath(state, PUBLIC_STATE_MAP[substate]);
     }
 
     return Object.keys(PUBLIC_STATE_MAP).reduce((publicState, property) => {
-      let path = PUBLIC_STATE_MAP[property];
       return Object.assign(
         publicState,
-        { [ property ]: selectPropByPath(path, state) }
+        { [ property ]: getByPath(state, PUBLIC_STATE_MAP[property]) }
       );
     }, {});
   }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,15 +5,15 @@ const filters = {
     return (
       item &&
       filters.ancestor(parent)(item) &&
-      item.id.replace(parent, '').split('.').length === 2
+      item.path.replace(parent, '').split('/').length === 2
     );
   },
 
   ancestor: ancestor => item => {
     return ( 
       item &&
-      item.id.indexOf(ancestor) === 0 &&
-      item.id.replace(ancestor, '').indexOf('.') === 0
+      item.path.indexOf(ancestor) === 0 &&
+      item.path.replace(ancestor, '').indexOf('/') === 0
     );
   },
 
@@ -25,41 +25,41 @@ export function get(obj, path) {
   return path.length === 0 || typeof obj === 'undefined' ? obj : get(obj[path[0]], path.slice(1));
 }
 
-export function selectDataFromState(uid, state) {
+export function selectDataFromState(path, state) {
   let content = state[DATA_PREFIX],
       data;
 
   if (content) {
-    data = content[uid];
+    data = content[path];
   }
 
   return data;
 }
 
-export function uidsToResponse(uids, state) {
+export function pathsToResponse(paths, state) {
   let content = state[DATA_PREFIX];
 
   return {
-    items: uids.map(uid => content[uid])
+    items: paths.map(path => content[path])
   };
 }
 
 export function findDataInState(query, state) {
   let content = state[DATA_PREFIX],
-      uids = [];
+      paths = [];
 
   if (!content) {
     return { items: [] };
   }
 
-  uids = Object.keys(query)
+  paths = Object.keys(query)
     .map(filterBy => filters[filterBy](query[filterBy]))
     .reduce(
-      (uids, filter) => uids.filter(uid => filter(content[uid])),
+      (paths, filter) => paths.filter(path => filter(content[path])),
       Object.keys(content)
     );
 
-  return uidsToResponse(uids, state);
+  return pathsToResponse(paths, state);
 }
 
 export function storeToObserver(store) {
@@ -181,6 +181,19 @@ export function toQueryParams(query = {}) {
     }, '');
 }
 
+export function toUidQuery(query) {
+  let newQuery = Object.assign({}, query),
+      paths = [ 'ancestor', 'parent' ];
+
+  paths.forEach(prop => {
+    if (prop in newQuery) {
+      newQuery[prop] = pathToUid(newQuery[prop]);
+    }
+  });
+
+  return newQuery;
+}
+
 export function hasRunQuery(query, state) {
   const queryState = state[QUERIES_PREFIX],
         queryParams = toQueryParams(query);
@@ -194,12 +207,12 @@ export function makeBlankItem() {
   };
 }
 
-export function makeItemWith(uid, item) {
+export function makeItemWith(path, item) {
   if (item === null) {
     return null
   };
 
-  return Object.assign(clone(item), { id: uid });
+  return Object.assign(clone(item), { path });
 }
 
 export function pathToUid(path) {
@@ -229,7 +242,7 @@ export function itemUidToPath(item) {
   let path,
       transformed;
 
-  if (!item) {
+  if (!item || !item.id) {
     return item;
   }
 
@@ -240,25 +253,24 @@ export function itemUidToPath(item) {
   return transformed;
 }
 
-export function queryResultsToPath(results) {
-  let items;
 
-  if (!results) {
-    return results;
-  }
-
-  items = results.items.map(itemUidToPath);
-
-  return Object.assign({}, results, { items });
-}
-
-export function validatePath(path) {
+export function pathIsInvalid(path) {
   if (path.charAt(0) !== '/') {
-    throw new Error(`Invalid path ${path}. Path must be a string starting with '/'`);
+    return new Error(`Invalid path ${path}. Path must be a string starting with '/'`);
   }
 
   if (path.indexOf('//') !== -1) {
-    throw new Error(`Invalid path '${path}'. Paths must not have more than one '/' in a row.`);
+    return new Error(`Invalid path '${path}'. Paths must not have more than one '/' in a row.`);
+  }
+
+  return false;
+}
+
+export function validatePath(path) {
+  let invalid = pathIsInvalid(path);
+
+  if (invalid) {
+    throw invalid;
   }
 }
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,6 +2,9 @@ import { DATA_PREFIX, QUERIES_PREFIX } from '../constants/state';
 
 const filters = {
   parent: parent => item => {
+    // Normalize path, mostly for '/' case
+    parent = parent.slice(-1) === '/' ? parent.slice(0, -1) : parent;
+
     return (
       item &&
       filters.ancestor(parent)(item) &&
@@ -10,6 +13,9 @@ const filters = {
   },
 
   ancestor: ancestor => item => {
+    // Normalize path, mostly for '/' case
+    ancestor = ancestor.slice(-1) === '/' ? ancestor.slice(0, -1) : ancestor;
+    
     return ( 
       item &&
       item.path.indexOf(ancestor) === 0 &&

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -47,18 +47,18 @@ export function selectPropByPath(path, obj) {
 }
 
 export function selectDataFromState(uid, state) {
-  let dataState = state[DATA_PREFIX],
+  let content = state[DATA_PREFIX],
       data;
 
-  if (dataState) {
-    data = dataState.content[uid];
+  if (content) {
+    data = content[uid];
   }
 
   return data;
 }
 
 export function uidsToResponse(uids, state) {
-  let { content } = state[DATA_PREFIX];
+  let content = state[DATA_PREFIX];
 
   return {
     items: uids.map(uid => content[uid])
@@ -66,21 +66,18 @@ export function uidsToResponse(uids, state) {
 }
 
 export function findDataInState(query, state) {
-  let dataState = state[DATA_PREFIX],
-      uids = [],
-      content;
+  let content = state[DATA_PREFIX],
+      uids = [];
 
-  if (!dataState) {
+  if (!content) {
     return { items: [] };
   }
-
-  content = dataState.content || {};
 
   uids = Object.keys(query)
     .map(filterBy => filters[filterBy](query[filterBy]))
     .reduce(
       (uids, filter) => uids.filter(uid => filter(content[uid])),
-      Object.keys(dataState.content)
+      Object.keys(content)
     );
 
   return uidsToResponse(uids, state);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -20,30 +20,9 @@ const filters = {
   type: expectedType => item => item && item.type === expectedType
 }
 
-export function selectPropByPath(path, obj) {
-  let selector,
-      numberSelector;
-
-  if (typeof obj === 'undefined') {
-    return obj;
-  }
-
-  if (typeof path === 'string') {
-    return selectPropByPath(path.split('.'), obj);
-  }
-
-  selector = path[0];
-  numberSelector = parseInt(selector);
-
-  if (!isNaN(numberSelector)) {
-    selector = numberSelector;
-  }
-
-  if (path.length === 0) {
-    return obj;
-  }
-
-  return selectPropByPath(path.slice(1), obj[selector]);
+export function get(obj, path) {
+  path = typeof path === 'string' ? path.split('.') : path;
+  return path.length === 0 || typeof obj === 'undefined' ? obj : get(obj[path[0]], path.slice(1));
 }
 
 export function selectDataFromState(uid, state) {
@@ -93,7 +72,7 @@ export function storeToObserver(store) {
           handleChange;
 
       getState = () => {
-        return selector ? selectPropByPath(selector, store.getState()) : store.getState();
+        return get(store.getState(), selector || []);
       }
 
       lastState = getState();

--- a/test/actions/api.js
+++ b/test/actions/api.js
@@ -96,6 +96,28 @@ describe('data crud', () => {
           expect(headers['Authorization'].split(' ')[1]).to.equal(TOKEN);
         });
     });
+
+    it('should remove path if given', () => {
+      let pathData = Object.assign({}, DATA, { path: '/foo' }),
+          store = mockStore({
+            config: {
+              dataEndpoint: SERVER
+            },
+            token: TOKEN
+          }),
+          expectedActions = [
+            setData(PATH, pathData),
+            setDataSuccessful(PATH, pathData, RESPONSE)
+          ];
+
+      return store.dispatch(set(PATH, pathData))
+        .then(() => {
+          let lastOptions = fetchMock.lastOptions(`${SERVER}/${UID}`),
+              body = JSON.parse(lastOptions.body);
+
+          expect(body).to.deep.equal(DATA);
+        });
+    });
   });
 
   describe('remove', () => {

--- a/test/actions/data.js
+++ b/test/actions/data.js
@@ -58,10 +58,7 @@ describe('data actions', () => {
         config: {
           dataEndpoint: SERVER
         },
-        [DATA_PREFIX]: {
-          content: {},
-          hierarchy: {}
-        }
+        [DATA_PREFIX]: {}
       };
       store = mockStore(initialState);
     });
@@ -114,12 +111,7 @@ describe('data actions', () => {
       // Partially fill buffer
       let [ firstItem, secondItem ] = BLANK_QUERY_ITEMS;
       initialState[DATA_PREFIX] = {
-        content: {
-          [ firstItem.id ]: firstItem
-        },
-        hierarchy: {
-          [ firstItem.id ]: {}
-        }
+        [ firstItem.id ]: firstItem
       };
 
       store = mockStore(initialState);
@@ -175,9 +167,7 @@ describe('data actions', () => {
 
   describe('get', () => {
     const data = {
-      content: {
-        [ UID_FOR_STORED ]: STORED_AT_UID
-      }
+      [ UID_FOR_STORED ]: STORED_AT_UID
     };
 
     it('should get value in the state', () => {
@@ -275,9 +265,7 @@ describe('data actions', () => {
 
       initialState = {
         [ DATA_PREFIX ]: {
-          content: {
-            [ knownAncestor ]: makeBlankItem()
-          }
+          [ knownAncestor ]: makeBlankItem()
         }
       };
 
@@ -360,18 +348,11 @@ describe('data actions', () => {
     it('should fire remove actions for children', () => {
       let store = mockStore({
         [ DATA_PREFIX ]: {
-          hierarchy: {
-            foo: {
-              bar: {}
-            }
+          'foo': {
+            id: 'foo'
           },
-          content: {
-            'foo': {
-              id: 'foo'
-            },
-            'foo.bar': {
-              id: 'foo.bar'
-            }
+          'foo.bar': {
+            id: 'foo.bar'
           }
         }
       });

--- a/test/reducers/buffer.js
+++ b/test/reducers/buffer.js
@@ -2,78 +2,78 @@ import { verboseReducer } from '../../src/reducers/buffer';
 import * as apiActions from '../../src/actions/api';
 import * as dataActions from '../../src/actions/data';
 
-const UID = 'some.uid';
-const RESPONSE = { id: UID, data: { foo: 'bar' } };
-const CHANGED = { id: UID, data: { foo: 'bar', baz: 'qux' } };
+const PATH = '/some/path';
+const RESPONSE = { path: PATH, data: { foo: 'bar' } };
+const CHANGED = { path: PATH, data: { foo: 'bar', baz: 'qux' } };
 const FIND_RESPONSE = { items: [ RESPONSE ] };
 
 describe('state of buffer', () => {
   it('should populate remote data from a `find` call', () => {
     let findSuccessful = apiActions.findDataSuccessful({}, FIND_RESPONSE);
-    expect(verboseReducer({}, findSuccessful)[UID].remote).to.deep.equal(RESPONSE);
+    expect(verboseReducer({}, findSuccessful)[PATH].remote).to.deep.equal(RESPONSE);
   });
 
   it('should handle updates to the Remote API', () => {
     let actions = [
-      [ apiActions.getDataSuccessful(UID, RESPONSE), RESPONSE ],
-      [ apiActions.setDataSuccessful(UID, null, RESPONSE), RESPONSE ],
-      [ apiActions.removeDataSuccessful(UID, RESPONSE), null ]
+      [ apiActions.getDataSuccessful(PATH, RESPONSE), RESPONSE ],
+      [ apiActions.setDataSuccessful(PATH, null, RESPONSE), RESPONSE ],
+      [ apiActions.removeDataSuccessful(PATH, RESPONSE), null ]
     ];
 
     actions.forEach(([ action, remoteState ]) => {
-      expect(verboseReducer({}, action)[UID].remote).to.deep.equal(remoteState);
+      expect(verboseReducer({}, action)[PATH].remote).to.deep.equal(remoteState);
     });
   });
 
   it('should handle updates to the internal state', () => {
     let actions = [
-      [ dataActions.setDataSuccessful(UID, RESPONSE), RESPONSE ],
-      [ dataActions.removeDataSuccessful(UID), null ]
+      [ dataActions.setDataSuccessful(PATH, RESPONSE), RESPONSE ],
+      [ dataActions.removeDataSuccessful(PATH), null ]
     ];
 
     actions.forEach(([ action, localState ]) => {
-      expect(verboseReducer({}, action)[UID].local).to.deep.equal(localState);
+      expect(verboseReducer({}, action)[PATH].local).to.deep.equal(localState);
     });
   });
 
   it('should not track local state when persist flag is false', () => {
     let persist = false,
         actions = [
-          dataActions.setDataSuccessful(UID, RESPONSE, { persist }),
-          dataActions.removeDataSuccessful(UID, { persist })
+          dataActions.setDataSuccessful(PATH, RESPONSE, { persist }),
+          dataActions.removeDataSuccessful(PATH, { persist })
         ];
 
     actions.forEach((action) => {
-      expect(verboseReducer({}, action)[UID]).to.not.exist;
+      expect(verboseReducer({}, action)[PATH]).to.not.exist;
     });
   });
 
   it('should remove items with persist: false already in save state if item flagged for deletion', () => {
-    let state = verboseReducer({ [ UID ]: {} }, dataActions.removeDataSuccessful(UID, { persist: false }));
+    let state = verboseReducer({ [ PATH ]: {} }, dataActions.removeDataSuccessful(PATH, { persist: false }));
 
-    expect(state[UID]).to.not.exist;
+    expect(state[PATH]).to.not.exist;
   });
 
   it('should reflect changes on the changed prop', () => {
     let initial = {
-          [ UID ]: {
+          [ PATH ]: {
             remote: RESPONSE,
             local: RESPONSE,
             changed: false
           }
         },
-        changed = verboseReducer(initial, dataActions.setDataSuccessful(UID, CHANGED)),
-        original = verboseReducer(initial, dataActions.setDataSuccessful(UID, RESPONSE));
+        changed = verboseReducer(initial, dataActions.setDataSuccessful(PATH, CHANGED)),
+        original = verboseReducer(initial, dataActions.setDataSuccessful(PATH, RESPONSE));
 
-    expect(changed[UID].changed).to.be.true;
-    expect(original[UID].changed).to.be.false;
+    expect(changed[PATH].changed).to.be.true;
+    expect(original[PATH].changed).to.be.false;
   });
 
   it('shouldn\'t pass object references in', () => {
     let data = { foo: 'bar' },
-        state = verboseReducer({}, dataActions.setDataSuccessful(UID, data));
+        state = verboseReducer({}, dataActions.setDataSuccessful(PATH, data));
 
     data.foo = 'baz';
-    expect(state[UID].local.foo).to.equal('bar');
+    expect(state[PATH].local.foo).to.equal('bar');
   });
 });

--- a/test/reducers/data.js
+++ b/test/reducers/data.js
@@ -4,11 +4,11 @@ import { makeItemWith } from '../../src/utils/helpers';
 
 describe('dataReducer', () => {
   describe('setting data', () => {
-    it('should create a flat map of uids to their data', () => {
-      let uid = 'foo.bar',
-          state = content({}, setDataSuccessful(uid, {}));
+    it('should create a flat map of paths to their data', () => {
+      let path = '/foo/bar',
+          state = content({}, setDataSuccessful(path, {}));
 
-      expect(state[uid]).to.deep.equal(makeItemWith(uid, {}));
+      expect(state[path]).to.deep.equal(makeItemWith(path, {}));
     });
 
     it('should store deep copies of the data', () => {
@@ -19,15 +19,15 @@ describe('dataReducer', () => {
       expect(state['foo'].foo.bar).to.equal('baz');
     });
 
-    it('should ensure the data set into the state contains the id prop', () => {
-      let uid = 'foo.bar',
-          state = content({}, setDataSuccessful(uid, {}));
+    it('should ensure the data set into the state contains the path prop', () => {
+      let path = '/foo/bar',
+          state = content({}, setDataSuccessful(path, {}));
 
-      expect(state[uid].id).to.equal(uid);
+      expect(state[path].path).to.equal(path);
     });
 
     it('should not set data if no change has occurred', () => {
-      let action = setDataSuccessful('foo.bar', {}),
+      let action = setDataSuccessful('/foo/bar', {}),
           initialState = content({}, action),
           secondaryState = content(initialState, action);
 
@@ -38,23 +38,23 @@ describe('dataReducer', () => {
   describe('removing data', () => {
     it('should set content at that point to null', () => {
       let state = content({
-        ['foo.bar']: {}
-      }, removeDataSuccessful('foo.bar'));
+        ['/foo/bar']: {}
+      }, removeDataSuccessful('/foo/bar'));
 
-      expect(state['foo.bar']).to.equal(null);
+      expect(state['/foo/bar']).to.equal(null);
     });
 
     it('should set to null even it didnt exist before', () => {
-      let state = content({}, removeDataSuccessful('foo.bar'));
-      expect(state['foo.bar']).to.equal(null);
+      let state = content({}, removeDataSuccessful('/foo/bar'));
+      expect(state['/foo/bar']).to.equal(null);
     });
 
     it('should not return a new object if it would make no difference', () => {
       let currentState = {
-        [ 'foo.bar' ]: null
+        [ '/foo/bar' ]: null
       };
 
-      expect(content(currentState, removeDataSuccessful('foo.bar'))).to.equal(currentState);
+      expect(content(currentState, removeDataSuccessful('/foo/bar'))).to.equal(currentState);
     });
   });
 });

--- a/test/reducers/data.js
+++ b/test/reducers/data.js
@@ -1,56 +1,22 @@
-import { hierarchy, content } from '../../src/reducers/data';
+import content from '../../src/reducers/data';
 import { setDataSuccessful, removeDataSuccessful } from '../../src/actions/data';
 import { makeItemWith } from '../../src/utils/helpers';
 
 describe('dataReducer', () => {
   describe('setting data', () => {
-    describe('hierarchy', () => {
-      it('should build a tree based on UID given', () => {
-        let state = hierarchy(undefined, setDataSuccessful('foo.bar.baz', {}));
-        expect(state.foo.bar.baz).to.be.defined;
-      });
+    it('should create a flat map of uids to their data', () => {
+      let uid = 'foo.bar',
+          state = content({}, setDataSuccessful(uid, {}));
 
-      it('shouldnt disturb other branches of the tree', () => {
-        let state = hierarchy({
-          foo: {
-            bar: {
-              baz: {}
-            }
-          },
-          baz: {
-            qux: {}
-          }
-        }, setDataSuccessful('foo.qux', {}));
-
-        expect(state).to.deep.equal({
-          foo: {
-            bar: {
-              baz: {}
-            },
-            qux: {}
-          },
-          baz: {
-            qux: {}
-          }
-        });
-      });
+      expect(state[uid]).to.deep.equal(makeItemWith(uid, {}));
     });
 
-    describe('content', () => {
-      it('should create a flat map of uids to their data', () => {
-        let uid = 'foo.bar',
-            state = content({}, setDataSuccessful(uid, {}));
+    it('should store deep copies of the data', () => {
+      let data = { foo: { bar: 'baz' } },
+          state = content({}, setDataSuccessful('foo', data));
 
-        expect(state[uid]).to.deep.equal(makeItemWith(uid, {}));
-      });
-
-      it('should store deep copies of the data', () => {
-        let data = { foo: { bar: 'baz' } },
-            state = content({}, setDataSuccessful('foo', data));
-
-        data.foo.bar = 'qux';
-        expect(state['foo'].foo.bar).to.equal('baz');
-      });
+      data.foo.bar = 'qux';
+      expect(state['foo'].foo.bar).to.equal('baz');
     });
 
     it('should ensure the data set into the state contains the id prop', () => {
@@ -70,49 +36,25 @@ describe('dataReducer', () => {
   });
 
   describe('removing data', () => {
-    describe('hierarchy', () => {
-      it('should remove the tree at that point', () => {
-        let state = hierarchy({
-          foo: {
-            bar: {
-              baz: {}
-            }
-          }
-        }, removeDataSuccessful('foo.bar'));
+    it('should set content at that point to null', () => {
+      let state = content({
+        ['foo.bar']: {}
+      }, removeDataSuccessful('foo.bar'));
 
-        expect(state.foo.bar).to.be.undefined;
-      });
-
-      it('should do nothing if it cant find that section of the tree', () => {
-        let state = hierarchy({
-          foo: {}
-        }, removeDataSuccessful('foo.bar.baz'));
-
-        expect(state.foo.bar).to.be.undefined;
-      });
+      expect(state['foo.bar']).to.equal(null);
     });
 
-    describe('content', () => {
-      it('should set content at that point to null', () => {
-        let state = content({
-          ['foo.bar']: {}
-        }, removeDataSuccessful('foo.bar'));
+    it('should set to null even it didnt exist before', () => {
+      let state = content({}, removeDataSuccessful('foo.bar'));
+      expect(state['foo.bar']).to.equal(null);
+    });
 
-        expect(state['foo.bar']).to.equal(null);
-      });
+    it('should not return a new object if it would make no difference', () => {
+      let currentState = {
+        [ 'foo.bar' ]: null
+      };
 
-      it('should set to null even it didnt exist before', () => {
-        let state = content({}, removeDataSuccessful('foo.bar'));
-        expect(state['foo.bar']).to.equal(null);
-      });
-
-      it('should not return a new object if it would make no difference', () => {
-        let currentState = {
-          [ 'foo.bar' ]: null
-        };
-
-        expect(content(currentState, removeDataSuccessful('foo.bar'))).to.equal(currentState);
-      });
+      expect(content(currentState, removeDataSuccessful('foo.bar'))).to.equal(currentState);
     });
   });
 });

--- a/test/simpla.js
+++ b/test/simpla.js
@@ -35,10 +35,6 @@ function resultsForFind(parent) {
   };
 }
 
-function makeAndPathItem(uid, data) {
-  return itemUidToPath(makeItemWith(uid, data));
-}
-
 function randomData() {
   return {
     foo: 'bar' + Math.random().toString(36).substr(5)
@@ -187,7 +183,7 @@ describe('Simpla', () => {
       it('should be able to get leaf node', () => {
         return Simpla.get('/foo/bar')
           .then(data => {
-            expect(data).to.deep.equal(makeAndPathItem('foo.bar', MOCK_DATA['/foo/bar']));
+            expect(data).to.deep.equal(makeItemWith('/foo/bar', MOCK_DATA['/foo/bar']));
           });
       });
 
@@ -299,8 +295,8 @@ describe('Simpla', () => {
       });
 
       it('should be able to filter by ancestor', () => {
-        let ancestor = '/foo/',
-            descendants = [ '/foo/bar/baz', '/foo/bar', '/foo/image', '/foo/bar/image', '/foo/baz/' ];
+        let ancestor = '/foo',
+            descendants = [ '/foo/bar/baz', '/foo/bar', '/foo/image', '/foo/bar/image', '/foo/baz' ];
 
         return Promise.all([
             Simpla.find({ ancestor }),
@@ -446,7 +442,7 @@ describe('Simpla', () => {
           return Simpla.set('/foo/bar', MOCK_DATA['/foo/bar'])
             .then(() => {
               expect(spy.getCall(0).args[0]).to.deep.equal({
-                items: [ makeAndPathItem('foo.bar', MOCK_DATA['/foo/bar']) ]
+                items: [ makeItemWith('/foo/bar', MOCK_DATA['/foo/bar']) ]
               })
             });
         });

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -1,6 +1,6 @@
 import {
   storeToObserver,
-  selectPropByPath,
+  get,
   dispatchThunkAndExpect,
   runDispatchAndExpect,
   dataIsValid,
@@ -21,21 +21,21 @@ import {
 import { createStore } from 'redux';
 
 describe('helpers', () => {
-  describe('selectPropByPath', () => {
+  describe('get', () => {
     it('should be able to select deep properties', () => {
-      expect(selectPropByPath('foo.bar.1.baz', {
+      expect(get({
         foo: {
-          bar: [{}, {
+          bar: {
             baz: 'qux'
-          }]
+          }
         }
-      })).to.equal('qux');
+      }, 'foo.bar.baz')).to.equal('qux');
     });
 
     it('should return undefined if selecting deep unknown', () => {
-      expect(selectPropByPath('foo.bar.baz', {
+      expect(get({
         foo: {}
-      })).to.be.undefined;
+      }, 'foo.bar.baz')).to.be.undefined;
     });
   });
 

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -232,30 +232,30 @@ describe('helpers', () => {
 
   describe('findDataInState', () => {
     let content = {
-          [ 'foo' ]: {
-            id: 'foo',
+          [ '/foo' ]: {
+            path: '/foo',
             data: {}
           },
 
-          [ 'foo.image' ]: {
-            id: 'foo.image',
+          [ '/foo/image' ]: {
+            path: '/foo/image',
             type: 'Image',
             data: {}
           },
 
-          [ 'foo.bar' ]: {
-            id: 'foo.bar',
+          [ '/foo/bar' ]: {
+            path: '/foo/bar',
             data: {}
           },
 
-          [ 'foo.bar.image' ]: {
-            id: 'foo.bar.image',
+          [ '/foo/bar/image' ]: {
+            path: '/foo/bar/image',
             type: 'Image',
             data: {}
           },
 
-          [ 'foo.bar.baz' ]: {
-            id: 'foo.bar.baz',
+          [ '/foo/bar/baz' ]: {
+            path: '/foo/bar/baz',
             data: {}
           }
         },
@@ -270,22 +270,22 @@ describe('helpers', () => {
 
     describe('parent scoped find', () => {
       it('should return only those directly below the parent uid', () => {
-        let query = { parent: 'foo' };
+        let query = { parent: '/foo' };
         expect(findDataInState(query, state).items).to.deep.have.members([
-          content['foo.bar'],
-          content['foo.image']
+          content['/foo/bar'],
+          content['/foo/image']
         ]);
       });
     });
 
     describe('ancestor scoped find', () => {
       it('should return only those below parent uid', () => {
-        let query = { ancestor: 'foo' };
+        let query = { ancestor: '/foo' };
         expect(findDataInState(query, state).items).to.deep.have.members([
-          content['foo.image'],
-          content['foo.bar'],
-          content['foo.bar.image'],
-          content['foo.bar.baz']
+          content['/foo/image'],
+          content['/foo/bar'],
+          content['/foo/bar/image'],
+          content['/foo/bar/baz']
         ]);
       });
     });
@@ -294,17 +294,17 @@ describe('helpers', () => {
       it('should return only with given type', () => {
         let query = { type: 'Image' };
         expect(findDataInState(query, state).items).to.deep.have.members([
-          content['foo.image'],
-          content['foo.bar.image']
+          content['/foo/image'],
+          content['/foo/bar/image']
         ]);
       });
     });
 
     describe('combined scoped find', () => {
       it('should return only those below parent uid', () => {
-        let query = { parent: 'foo', type: 'Image' };
+        let query = { parent: '/foo', type: 'Image' };
         expect(findDataInState(query, state).items).to.deep.have.members([
-          content['foo.image']
+          content['/foo/image']
         ]);
       });
     });
@@ -318,18 +318,18 @@ describe('helpers', () => {
 
   describe('matchesQuery', () => {
     it('should match parent queries', () => {
-      let childContent = { id: 'foo.bar' },
-          notChildContent = { id: 'bar.baz' },
-          query = { parent: 'foo' };
+      let childContent = { path: '/foo/bar' },
+          notChildContent = { path: '/bar/baz' },
+          query = { parent: '/foo' };
 
       expect(matchesQuery(query, childContent)).to.be.true;
       expect(matchesQuery(query, notChildContent)).to.be.false;
     });
 
     it('should match ancestor queries', () => {
-      let descendant = { id: 'foo.bar.baz' },
-          notDescendant = { id: 'bar' },
-          query = { ancestor: 'foo' };
+      let descendant = { path: '/foo/bar/baz' },
+          notDescendant = { path: '/bar' },
+          query = { ancestor: '/foo' };
 
       expect(matchesQuery(query, descendant)).to.be.true;
       expect(matchesQuery(query, notDescendant)).to.be.false;
@@ -345,16 +345,16 @@ describe('helpers', () => {
     });
 
     it('should match combined queries', () => {
-      let imageAndDescendant = { id: 'foo.bar.baz', type: 'Image' },
-          justImage = { id: 'foo', type: 'Image' },
-          query = { type: 'Image', ancestor: 'foo' };
+      let imageAndDescendant = { path: '/foo/bar/baz', type: 'Image' },
+          justImage = { path: '/foo', type: 'Image' },
+          query = { type: 'Image', ancestor: '/foo' };
 
       expect(matchesQuery(query, imageAndDescendant)).to.be.true;
       expect(matchesQuery(query, justImage)).to.be.false;
     });
 
     it('should match everything for empty query', () => {
-      [{ id: 'foo' }, { id: 'foo.bar' }, { id: 'bar' }]
+      [{ path: 'foo' }, { path: '/foo/bar' }, { path: '/bar' }]
         .forEach(content => {
           expect(matchesQuery({}, content)).to.be.true;
         });
@@ -392,8 +392,8 @@ describe('helpers', () => {
 
   describe('makeItemWith', () => {
     it('should combine id and data', () => {
-      expect(makeItemWith('foo', { foo: 'bar' })).to.deep.equal({
-        id: 'foo',
+      expect(makeItemWith('/foo', { foo: 'bar' })).to.deep.equal({
+        path: '/foo',
         foo: 'bar'
       });
     });

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -276,6 +276,14 @@ describe('helpers', () => {
           content['/foo/image']
         ]);
       });
+
+      it('should accept / as parent of /*', () => {
+        let query = { parent: '/' };
+
+        expect(findDataInState(query, state).items).to.deep.have.members([
+          content['/foo']
+        ]);
+      });
     });
 
     describe('ancestor scoped find', () => {
@@ -287,6 +295,14 @@ describe('helpers', () => {
           content['/foo/bar/image'],
           content['/foo/bar/baz']
         ]);
+      });
+
+      it('should accept / as ancestor of /*', () => {
+        let query = { ancestor: '/' };
+
+        expect(findDataInState(query, state).items).to.deep.have.members(
+          Object.values(content)
+        );
       });
     });
 

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -259,17 +259,7 @@ describe('helpers', () => {
             data: {}
           }
         },
-        hierarchy = {
-          foo: {
-            bar: {
-              image: {},
-              baz: {}
-            },
-            image: {}
-          }
-        },
-        state = { [ DATA_PREFIX ]: { content, hierarchy  }
-    };
+        state = { [ DATA_PREFIX ]: content };
 
     describe('general find', () => {
       it('should return all items', () => {


### PR DESCRIPTION
This fixes an issue where querying against `/` (in both `parent` and `ancestor` queries) was failing. It also moves from `uid` -> `path` in almost all areas of the SDK, UIDs only come into it when finally making requests to the API.